### PR TITLE
ダークモードをサポートする

### DIFF
--- a/Sources/Loader/Loader.swift
+++ b/Sources/Loader/Loader.swift
@@ -37,17 +37,17 @@ extension UIColor {
 
     static func backgroundFadedGrey()->UIColor
     {
-        return UIColor(red: (246.0/255.0), green: (247.0/255.0), blue: (248.0/255.0), alpha: 1)
+        return UIColor.systemGray6
     }
 
     static func gradientFirstStop()->UIColor
     {
-        return  UIColor(red: (238.0/255.0), green: (238.0/255.0), blue: (238.0/255.0), alpha: 1.0)
+        return UIColor.systemGray5
     }
 
     static func gradientSecondStop()->UIColor
     {
-        return UIColor(red: (221.0/255.0), green: (221.0/255.0), blue:(221.0/255.0) , alpha: 1.0);
+        return UIColor.systemGray4
     }
 }
 
@@ -103,7 +103,7 @@ class CutoutView : UIView
             return
         }
 
-        context.setFillColor(UIColor.white.cgColor)
+        context.setFillColor(UIColor.systemBackground.cgColor)
         context.fill(self.bounds)
 
         for view in subviews where view != self {


### PR DESCRIPTION
ダークモードをサポートしました。カラーコードを直指定している箇所は、一番近いシステムカラーに置き換えました。微妙にライトモードでも色が違いますが（僅かに濃い、黒寄り）、ほぼ分からなかったので許容しています。気になる人や、懸念がある人がいれば、ダークモードの色だけ対応します

ref: https://ios-docs.dev/swift-color/

<img width="813" alt="スクリーンショット 2024-02-08 17 51 16" src="https://github.com/fumito-ito/Loader.swift/assets/26104258/8e7911b7-a949-4a90-bb29-d8e721c7e4d6">
